### PR TITLE
Support pca interpolation steps

### DIFF
--- a/Jobs/Alis/api.py
+++ b/Jobs/Alis/api.py
@@ -103,7 +103,7 @@ def run_pca():
     AlisWrapper.run_pca_moving_on_file(
         file_path = vector_path,
         out_folder = app.config['OUTPUT_PCA'], 
-        interpolation_steps = 1,
+        interpolation_steps = params['interpolation_steps'],
         latent_edits = latent_edits
     )
 

--- a/Jobs/Alis/api.py
+++ b/Jobs/Alis/api.py
@@ -103,7 +103,7 @@ def run_pca():
     AlisWrapper.run_pca_moving_on_file(
         file_path = vector_path,
         out_folder = app.config['OUTPUT_PCA'], 
-        interpolation_steps = params['interpolation_steps'],
+        interpolation_steps = params.get('interpolation_steps', 1),
         latent_edits = latent_edits
     )
 

--- a/Jobs/Stylegan2/api.py
+++ b/Jobs/Stylegan2/api.py
@@ -119,7 +119,7 @@ def run_pca():
         network_pkl = models_config[model]['checkpoint'],
         file_path = vector_path,
         out_folder = app.config['OUTPUT_PCA'], 
-        interpolation_steps = params['interpolation_steps'],
+        interpolation_steps = params.get('interpolation_steps', 1),
         latent_edits = latent_edits
     )
 

--- a/Jobs/Stylegan2/api.py
+++ b/Jobs/Stylegan2/api.py
@@ -119,7 +119,7 @@ def run_pca():
         network_pkl = models_config[model]['checkpoint'],
         file_path = vector_path,
         out_folder = app.config['OUTPUT_PCA'], 
-        interpolation_steps = 1,
+        interpolation_steps = params['interpolation_steps'],
         latent_edits = latent_edits
     )
 

--- a/Jobs/Worker/worker.py
+++ b/Jobs/Worker/worker.py
@@ -60,6 +60,7 @@ data field specification for Alis endpoints
 {
     'endpoint': '/run_projection'
     "vector_id": <pkl_vector>,
+    "interpolation_steps": <amount_of_samples (in case of missing is set to 1 by default)> 
     "latent_edits": [
         {
             "principal_component_number": <component>,
@@ -90,7 +91,8 @@ def alisApi(data):
     elif data['data']['endpoint'] == '/run_pca':
         jsonData = {
             'vector_id': data['data']['vector_id'],
-            'latent_edits': data['data']['latent_edits']
+            'latent_edits': data['data']['latent_edits'],
+            'interpolation_steps': data['data'].get('interpolation_steps', 1),
         }
         response = requests.post(f"http://{Config.ALIS_ROUTE}:{Config.ALIS_PORT}/run_pca", json=jsonData)
         return json.loads(response.content)
@@ -127,6 +129,7 @@ data field specification for Stylegan2 endpoints
     'endpoint': '/run_projection'
     'model': <model_name>,
     "vector_id": <pkl_vector>,
+    "interpolation_steps": <amount_of_samples (in case of missing is set to 1 by default)> 
     "latent_edits": [
         {
             "principal_component_number": <component>,
@@ -160,7 +163,8 @@ def Stylegan2Api(data):
         jsonData = {
             'model': data['data']['model'],
             'vector_id': data['data']['vector_id'],
-            'latent_edits': data['data']['latent_edits']
+            'latent_edits': data['data']['latent_edits'],
+            'interpolation_steps': data['data'].get('interpolation_steps', 1),
         }
         response = requests.post(f"http://{Config.STYLEGAN2_ROUTE}:{Config.STYLEGAN2_PORT}/run_pca", json=jsonData)
         return json.loads(response.content)


### PR DESCRIPTION
Add support for passing amount of interpolation steps to worker in the message. In case of no param set in the request, the value of 1 is used as default. 

The images are numbered from 0 to interpolation_steps - 1.